### PR TITLE
Support for dac and browser apps (#15)

### DIFF
--- a/scripts/browser.sh
+++ b/scripts/browser.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+function stop_browser()
+{
+  curl -X PUT http://127.0.0.1/Service/Controller/Deactivate/WebKitBrowser
+  exit
+}
+
+curl -X PUT http://127.0.0.1/Service/Controller/Activate/WebKitBrowser
+curl -d "{\"url\":\"$1\"}" http://127.0.0.1/Service/WebKitBrowser/URL
+trap stop_browser SIGINT SIGTERM
+while true
+do
+    sleep 1
+done

--- a/src/cache/apps-reference-image.json
+++ b/src/cache/apps-reference-image.json
@@ -1,0 +1,85 @@
+[
+    {
+        "appType": "dac",
+        "logo": "wayland.png",
+        "title": "Wayland test",
+        "cmd": "dac wayland-egl-test"
+    },
+    {
+        "appType": "dac",
+        "logo": "",
+        "title": "You.I",
+        "cmd": "dac you.i"
+    },
+    {
+        "appType": "dac",
+        "logo": "",
+        "title": "Flutter",
+        "cmd": "dac flutter"
+    },
+    {
+        "appType": "browser",
+        "logo": "HTML5_Badge_128.png",
+        "title": "HTML5 Test",
+        "cmd": "browser http://html5test.com/"
+    },
+    {
+        "appType": "browser",
+        "logo": "css3-icon-28.jpg",
+        "title": "CSS3 Test",
+        "cmd": "browser https://css3test.com/"
+    },
+    {
+        "appType": "browser",
+        "logo": "google.jpg",
+        "title": "Google",
+        "cmd": "browser https://google.com"
+    },
+    {
+        "appType": "spark",
+        "logo": "spark.png",
+        "title": "gallery",
+        "url": "http://www.pxscene.org/examples/px-reference/gallery/gallery3.js"
+    },
+    {
+        "appType": "spark",
+        "logo": "spark.png",
+        "title": "fishtank",
+        "url": "http://www.pxscene.org/examples/px-reference/gallery/fishtank/fishtank.js"
+    },
+    {
+        "appType": "spark",
+        "logo": "spark.png",
+        "title": "playmask",
+        "url": "http://www.pxscene.org/examples/px-reference/gallery/playmask.js"
+    },
+    {
+        "appType": "spark",
+        "logo": "spark.png",
+        "title": "polaroid",
+        "url": "http://www.pxscene.org/examples/px-reference/polaroid/pp_polaroid.js"
+    },
+    {
+        "appType": "spark",
+        "logo": "spark.png",
+        "title": "coverflow",
+        "url": "http://px-apps.sys.comcast.net/pxscene-samples/examples/px-reference/gallery/coverflowtest_v2.js"
+    },
+    {
+        "appType": "native",
+        "logo": "cobalt-logo.png",
+        "title": "Cobalt YT",
+        "cmd": "cobalt"
+    },
+    {
+        "appType": "native",
+        "logo": "wayland.png",
+        "title": "Wayland test",
+        "cmd": "westeros_test"
+    },
+    {
+        "appType": "native",
+        "logo": "default_app_collection.png",
+        "title": "Netflix"
+    }
+]

--- a/src/networks/comcast/constants.js
+++ b/src/networks/comcast/constants.js
@@ -48,6 +48,8 @@ const appTypesMap = {
     html5: 'WebApp',
     spark: 'spark',
     native: 'native',
+    dac: 'dac',
+    browser: 'browser',
 };
 
 const appStatuses = {

--- a/src/networks/comcast/index.js
+++ b/src/networks/comcast/index.js
@@ -55,6 +55,8 @@ module.exports = {
         let launchParams = {};
         switch (app.appType) {
             case 'native':
+            case 'dac':
+            case 'browser':
                 launchParams = { cmd: app.cmd };
                 break;
             default:


### PR DESCRIPTION
* Add Downloadable Application Container support

* add dac apptype and 3 demo apps

* Add browser app support via wpeframework plugin webkitbrowser

* also add separate apps.json for reference image

* Update dac.sh: remove SIGKILL trap